### PR TITLE
Bug: sistema permitindo cadastro de competencias duplicadas para uma tarefa

### DIFF
--- a/laravel/app/Http/Controllers/SearchController.php
+++ b/laravel/app/Http/Controllers/SearchController.php
@@ -46,14 +46,11 @@ class SearchController extends Controller
     public function autoCompleteCompetence(Request $request) {
         $query = $request->get('term','');
         $blackListedIds = $request->get('blacklistedIds',[]);
-        $competencies=Competency::where('name','LIKE','%'.$query.'%')->limit(20)->get();
+        $competencies=Competency::where('name','LIKE','%'.$query.'%')->whereNotIn('id', $blackListedIds)->limit(20)->get();
 
         $data=array();
         foreach ($competencies as $competence) {
-            if (!in_array($competence->id, $blackListedIds)) {
-                $data[]=array('value'=>$competence->name,'id'=>$competence->id);
-            }
-
+            $data[]=array('value'=>$competence->name,'id'=>$competence->id);
         }
         if(count($data))
             return $data;

--- a/laravel/app/Http/Controllers/SearchController.php
+++ b/laravel/app/Http/Controllers/SearchController.php
@@ -45,11 +45,15 @@ class SearchController extends Controller
     }
     public function autoCompleteCompetence(Request $request) {
         $query = $request->get('term','');
+        $blackListedIds = $request->get('blacklistedIds',[]);
         $competencies=Competency::where('name','LIKE','%'.$query.'%')->limit(20)->get();
 
         $data=array();
         foreach ($competencies as $competence) {
-            $data[]=array('value'=>$competence->name,'id'=>$competence->id);
+            if (!in_array($competence->id, $blackListedIds)) {
+                $data[]=array('value'=>$competence->name,'id'=>$competence->id);
+            }
+
         }
         if(count($data))
             return $data;

--- a/laravel/app/Http/Controllers/TaskController.php
+++ b/laravel/app/Http/Controllers/TaskController.php
@@ -54,7 +54,14 @@ class TaskController extends Controller
         for ($i=0; $i<sizeOf($competenceIds); $i++) {
             $competenceId = $competenceIds[$i];
             $competenceProficiencyLevel = $competenceProficiencyLevels[$i];
-            $task->competencies()->attach([$competenceId => ['competency_proficiency_level_id'=>$competenceProficiencyLevel]]);
+            $results = $task->competencies()->where('competency_id', '=', $competenceId)->get();
+            if ($results->isEmpty()) {
+                //add competency
+                $task->competencies()->attach([$competenceId => ['competency_proficiency_level_id'=>$competenceProficiencyLevel]]);
+            } else {
+                //update competency level
+                $task->competencies()->updateExistingPivot($competenceId, ['competency_proficiency_level_id'=>$competenceProficiencyLevel]);
+            }
         }
         return Redirect::route('tasks.show',$task->id)->withMessage('A tarefa foi cadastrada com sucesso!');
     }

--- a/laravel/app/Http/Controllers/TaskController.php
+++ b/laravel/app/Http/Controllers/TaskController.php
@@ -104,7 +104,14 @@ class TaskController extends Controller
         for ($i=0; $i<sizeOf($competenceIds); $i++) {
             $competenceId = $competenceIds[$i];
             $competenceProficiencyLevel = $competenceProficiencyLevels[$i];
-            $task->competencies()->attach([$competenceId => ['competency_proficiency_level_id'=>$competenceProficiencyLevel]]);
+            $results = $task->competencies()->where('competency_id', '=', $competenceId)->get();
+            if ($results->isEmpty()) {
+                //add competency
+                $task->competencies()->attach([$competenceId => ['competency_proficiency_level_id'=>$competenceProficiencyLevel]]);
+            } else {
+                //update competency level
+                $task->competencies()->updateExistingPivot($competenceId, ['competency_proficiency_level_id'=>$competenceProficiencyLevel]);
+            }
         }
         return Redirect::route('tasks.show',$task->id)->withMessage('A tarefa foi atualizada com sucesso!');
     }

--- a/laravel/resources/views/competences/add_competences_without_button.blade.php
+++ b/laravel/resources/views/competences/add_competences_without_button.blade.php
@@ -98,13 +98,26 @@
 
         return code;
     }
+    function competenceInTable(competenceId) {
+        var result = false;
+        $('[name="competence_ids[]"]').each(function(){
+            if($(this).val() == competenceId) {
+                result = true;
+               return;
+            }
+        });
+        return result;
+    }
     function addCompetence(name, competenceId, numberOfLevels) {
         var current_number_rows = getCurrentNumberOfRows("addCompetenceTable");
         if (current_number_rows == 0) {
             toggleTable();
         }
-        //add new competenceToTable
-        $("#addCompetenceTable").append(getCompetenceRowCode(name, competenceId, numberOfLevels));
+        if(!competenceInTable(competenceId)) {
+            //add new competenceToTable
+            $("#addCompetenceTable").append(getCompetenceRowCode(name, competenceId, numberOfLevels));
+
+        }
     }
     function removeCompetence() {
         var current_number_rows = getCurrentNumberOfRows("addCompetenceTable");
@@ -117,6 +130,13 @@
         var sliderLabel = rowHit.find(".competence_level_label");
         var newLabel = getLabelForSliderValue(slider.value);
         sliderLabel.html(newLabel);
+    }
+    function getCurrentCompetenceIdsInTable() {
+        var lista = [];
+        $('[name="competence_ids[]"]').each(function(){
+            lista.push($(this).val());
+        });
+        return lista;
     }
     $(document).ready(function () {
         $.ajaxSetup({
@@ -139,8 +159,6 @@
             return tmp;
         }();
         var numberOfCategories = {{\App\CompetenceProficiencyLevel::count()}}
-        console.log(numberOfCategories);
-        console.log(dictionary);
         document.getElementById("addCompetenceTable").style.display = "none";
         $("#addCompetenceTable").on('click', '.remove_unsaved_competence', function () {
             $(this).parent().parent().remove();
@@ -153,7 +171,8 @@
                     url: src_competence,
                     dataType: "json",
                     data: {
-                        term: request.term
+                        term: request.term,
+                        blacklistedIds:  getCurrentCompetenceIdsInTable()
                     },
                     success: function (data) {
                         response(data);

--- a/laravel/resources/views/competences/add_competences_without_button.blade.php
+++ b/laravel/resources/views/competences/add_competences_without_button.blade.php
@@ -98,26 +98,13 @@
 
         return code;
     }
-    function competenceInTable(competenceId) {
-        var result = false;
-        $('[name="competence_ids[]"]').each(function(){
-            if($(this).val() == competenceId) {
-                result = true;
-               return;
-            }
-        });
-        return result;
-    }
     function addCompetence(name, competenceId, numberOfLevels) {
         var current_number_rows = getCurrentNumberOfRows("addCompetenceTable");
         if (current_number_rows == 0) {
             toggleTable();
         }
-        if(!competenceInTable(competenceId)) {
-            //add new competenceToTable
-            $("#addCompetenceTable").append(getCompetenceRowCode(name, competenceId, numberOfLevels));
-
-        }
+        //add new competenceToTable
+        $("#addCompetenceTable").append(getCompetenceRowCode(name, competenceId, numberOfLevels));
     }
     function removeCompetence() {
         var current_number_rows = getCurrentNumberOfRows("addCompetenceTable");

--- a/laravel/resources/views/users/add_competences_with_button.blade.php
+++ b/laravel/resources/views/users/add_competences_with_button.blade.php
@@ -102,6 +102,13 @@
         var newLabel = getLabelForSliderValue(slider.value);
         sliderLabel.html(newLabel);
     }
+    function getCurrentCompetenceIdsInTable() {
+        var lista = [];
+        $('[name="competence_id[]"]').each(function(){
+            lista.push($(this).val());
+        });
+        return lista;
+    }
     $(document).ready(function () {
         $.ajaxSetup({
             headers: {
@@ -135,7 +142,8 @@
                     url: src_competence,
                     dataType: "json",
                     data: {
-                        term: request.term
+                        term: request.term,
+                        blacklistedIds:  getCurrentCompetenceIdsInTable()
                     },
                     success: function (data) {
                         response(data);


### PR DESCRIPTION
Resolvi tanto no backend quanto no frontend (teoricamente o bug j'a estaria resolvido s'o mudando o frontend mas eh boa pratica consertar todos os lugares que podem gerar o bug)
- Resolução no backend: ao receber uma nova competencia para adicionar à tarefa, verificar se aquela competencia já existe na lista de competencias da tarefa. Se não existir, adicionar, se existir apenas atualizar o nivel de proficiencia.
- Resolucao no frontend: adicionar na query do autocomplete uma lista de balcklisted ids das competencias. Os ids que vão estar nessa blacklist são os id's das competencias que ja estão na tabela de adição e, portanto, não precisam estar incluidos no auto complete de novo.
Assim, por exemplo...se o sistema tiver apenas as competencias "abc1", "abc2" e "abc3" e você digitar "abc" na busca de competencias..a sugestao vai retornar as 3 competencias...Se você clicar na competencia 2 pra adicionar ela na tabela de competencias que aparece na view, a competencia vai aparecer na tabela. Dai se voce digitar de novo "abc"na busca, dessa vez as sugestoes só vão mostrar as competencias 1 e 3 (porque a 2 já está na tabela).
Fiz essa modificação para todo o sistema, então teoricamente o mesmo vai acontecer pra competencias do usuario.
